### PR TITLE
Allow user to input "0" as value

### DIFF
--- a/src/brightness.py
+++ b/src/brightness.py
@@ -7,7 +7,7 @@ def main(wf):
     user_input = wf.args[0]
     if user_input != '':
         try:
-            if int(user_input) <= 100 and int(user_input) > 0:
+            if int(user_input) <= 100 and int(user_input) >= 0:
                 wf.add_item('%s%%' % user_input, arg='%s' % (int(user_input) / 100.0), valid=True)
             else:
                 wf.add_item('Enter value between 0 and 100')


### PR DESCRIPTION
When entering ```0``` as value for this it says *Enter value between 0 and 100*. This PR is a fix for allowing the user to input ```0``` as value.